### PR TITLE
remove rsync from install

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,7 +58,6 @@ apt-get -y -q install \
   unzip \
   vim \
   whois \
-  rsync \
   libffi-dev \
   python3-pip \
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- See title

## security considerations
Removing rsync from installation path makes it so that our container audit can pass