### PR TITLE
Install GitHub CLI

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -196,4 +196,14 @@ wget https://github.com/cloudfoundry-incubator/uaa-cli/releases/download/0.10.0/
 mv uaa-linux-amd64-0.10.0 /usr/bin/uaa
 chmod a+x /usr/bin/uaa
 
+echo "Installing GitHub CLI"
+# Instructions adapted from: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+apt update
+apt install gh -y
+
 rm -rf /var/lib/apt/lists/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -201,7 +201,7 @@ echo "Installing GitHub CLI"
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
   | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 apt update
 apt install gh -y


### PR DESCRIPTION
I plan to use this to create pull requests from Concourse jobs.

## security considerations

Installs a new dependency from a trusted source, per the official GitHub CLI [installation documentation](https://github.com/cli/cli/blob/trunk/docs/install_linux.md). As noted in the documentation, other sources are community-maintained.
