### PR TITLE
add python-venv package

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,12 +59,13 @@ apt-get -y -q install \
   vim \
   whois \
   libffi-dev \
-  python3-pip
+  python3-pip \
+  python3-venv
 
 apt-get clean
 
 # symlink python to python3 executable
-ln -s $(which python3) /usr/bin/python
+ln -s "$(which python3)" /usr/bin/python
 
 #upgrade pip and install necessary packages
 echo "Upgrading python packages"


### PR DESCRIPTION
## Changes proposed in this pull request:

add `python-venv` to fix errors when trying to build virtual environments for python projects in CI, such as:

```
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.10-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.
```

## security considerations

None, just adding a package to support Python virtual environments. These changes will go through the usual audit/testing before promotion for wider use
