### PR TITLE
update bosh cli to latest version

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -12,8 +12,6 @@ TERRAFORM_RELEASE_VERSION=1.5.3
 TERRAFORM_TEST_RELEASE_VERSION=1.5.3
 CF_CLI_RELEASE_VERSION7=7.7.1
 CREDHUB_CLI_RELEASE_VERSION=2.9.18
-# bosh-cli gets really slow at 6.2.0, so we're pinned here.
-# check https://github.com/cloudfoundry/bosh-cli/issues/570 for details
 BOSH_CLI_V2_RELEASE_VERSION=7.5.4
 UAAC_CLI_RELEASE_VERSION=4.14.0
 RUBY_RELEASE_VERSION=3.2.2

--- a/config.sh
+++ b/config.sh
@@ -14,7 +14,7 @@ CF_CLI_RELEASE_VERSION7=7.7.1
 CREDHUB_CLI_RELEASE_VERSION=2.9.18
 # bosh-cli gets really slow at 6.2.0, so we're pinned here.
 # check https://github.com/cloudfoundry/bosh-cli/issues/570 for details
-BOSH_CLI_V2_RELEASE_VERSION=7.2.3
+BOSH_CLI_V2_RELEASE_VERSION=7.5.4
 UAAC_CLI_RELEASE_VERSION=4.14.0
 RUBY_RELEASE_VERSION=3.2.2
 RAKE_RELEASE_VERSION=13.0.6

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,7 +153,8 @@ echo "Installing uaac"
 gem install cf-uaac -v "$UAAC_CLI_RELEASE_VERSION" --no-document
 
 echo "Installing BOSH CLI v2 version ${BOSH_CLI_V2_RELEASE_VERSION}"
-curl -L -o /usr/local/bin/bosh "https://github.com/cloudfoundry/bosh-cli/releases/download/${BOSH_CLI_V2_RELEASE_VERSION}/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
+curl -L -o /usr/local/bin/bosh "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_V2_RELEASE_VERSION}/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
+
 chmod +x /usr/local/bin/bosh
 ln -s /usr/local/bin/bosh /usr/local/bin/bosh2
 ln -s /usr/local/bin/bosh /usr/local/bin/bosh-cli

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,7 +153,7 @@ echo "Installing uaac"
 gem install cf-uaac -v "$UAAC_CLI_RELEASE_VERSION" --no-document
 
 echo "Installing BOSH CLI v2 version ${BOSH_CLI_V2_RELEASE_VERSION}"
-curl -L -o /usr/local/bin/bosh "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
+curl -L -o /usr/local/bin/bosh "https://github.com/cloudfoundry/bosh-cli/releases/download/${BOSH_CLI_V2_RELEASE_VERSION}/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
 chmod +x /usr/local/bin/bosh
 ln -s /usr/local/bin/bosh /usr/local/bin/bosh2
 ln -s /usr/local/bin/bosh /usr/local/bin/bosh-cli


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update bosh from v7.2.3 to v7.5.4
- Change source of the binary file to the github repo
- Notable changes:
  - Add create-recovery-plan command by @selzoc in https://github.com/cloudfoundry/bosh-cli/pull/622
  - Add bosh recover command by @selzoc in https://github.com/cloudfoundry/bosh-cli/pull/623
  - Update to golang 1.20.6
  - Add --force-latest-variables flag to deploy command by @selzoc in https://github.com/cloudfoundry/bosh-cli/pull/625
  - Remove git rev and timestamp from version number by @jpalermo in https://github.com/cloudfoundry/bosh-cli/pull/628
  - Bump actions/setup-go from 3 to 4 by https://github.com/dependabot in https://github.com/cloudfoundry/bosh-cli/pull/615
  - Shell autocomplete for bosh-cli by @kinjelom in https://github.com/cloudfoundry/bosh-cli/pull/629
  - Implement pcap cmd by @b1tamara in https://github.com/cloudfoundry/bosh-cli/pull/627
  - Enable global flags for deploy command by @fmoehler in https://github.com/cloudfoundry/bosh-cli/pull/634
  - When debugging requests, do not dump the body of the request. by @jpalermo in https://github.com/cloudfoundry/bosh-cli/pull/638
  - Bump to gopkg.in/yaml.v2 to v3 in the release/manifest package by @crhntr in https://github.com/cloudfoundry/bosh-cli/pull/639
  - repack-stemcell stops prefixing archive members with "./" by @selzoc in https://github.com/cloudfoundry/bosh-cli/pull/641
## security considerations
Updating the bosh cli version also comes with CVE fixes
