### PR TITLE
set ruby in shell

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,6 +104,7 @@ git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-b
 
 rbenv install $RUBY_CMD_VERSION
 rbenv global $RUBY_CMD_VERSION
+rbenv shell $RUBY_CMD_VERSION
 
 update-ca-certificates
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use rbenv shell command to set ruby version used in shell

## security considerations
None, fixing how ruby runs
