### PR TITLE
cleanup go cache as it is not needed

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -246,3 +246,7 @@ echo "Installing Alertmanager CLI"
 go install github.com/prometheus/alertmanager/cmd/amtool@latest
 
 rm -rf /var/lib/apt/lists/*
+
+#cleanup go cache
+go clean -cache
+go clean -modcache

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -195,7 +195,7 @@ tar xvaf "v${GH_RELEASE_VERSION}.tar.gz"
 pushd "cli-${GH_RELEASE_VERSION}"
   make install
 popd
-rm -r cli-${GH_RELEASE_VERSION} v{$GH_RELEASE_VERSION}.tar.gz
+rm -rf cli-${GH_RELEASE_VERSION} v{$GH_RELEASE_VERSION}.tar.gz
 
 apt-get clean
 rm -rf /var/cache/apt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -195,6 +195,7 @@ tar xvaf "v${GH_RELEASE_VERSION}.tar.gz"
 pushd "cli-${GH_RELEASE_VERSION}"
   make install
 popd
+rm -r cli-${GH_RELEASE_VERSION} v{$GH_RELEASE_VERSION}.tar.gz
 
 apt-get clean
 rm -rf /var/cache/apt


### PR DESCRIPTION
## Changes proposed in this pull request:
- This adds code to clean up the go cache and modcache which will significantly reduce the size of the image
- This will also remove go files that grype was alerting
- Also clean up files from install of gh

## security considerations
Reducing image size and improving grype issue reporting
