### PR TITLE
Adds mysql-client to the build package list

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,6 +54,7 @@ apt-get -qq -y install --no-install-recommends \
   libxml2-dev \
   libxslt1-dev \
   libyaml-dev \
+  mysql-client \
   openssl \
   postgresql-client \
   postgresql-client-common \


### PR DESCRIPTION
We are currently missing the mysql-client package, which prevents us from interacting or doing anything with MySQL databases in the containers.  This changeset adds it in.

## Changes proposed in this pull request:
- Adds the MySQL client to the package install list

## security considerations
- This adds the `mysql-client` `apt`-managed release to our installed packages.
