### PR TITLE
Attempt to fix issue pasting while SSHed into general-task image

### DIFF
--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,1 @@
+set enable-bracketed-paste 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ FROM ${base_image}
 # Copy local project directories to container image
 COPY . /opt/concourse-ci/task
 
+# Configure readline to fix issues with bracketed paste mode in SSH
+COPY .inputrc /root/.inputrc
+
 # Set current working directory for executed scripts
 WORKDIR /opt/concourse-ci/task
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Several people on the team experience issues pasting while SSH'd into a container based on general-task, including our jumpbox containers. Specifically, the pasted sequence is either surrounded by tildes, ~like this~, or the first six characters are either dropped or repeated at random. The bracketed paste control characters are six characters long and if not handled correctly can result in this behavior.

This commit adds an .inputrc to the root user's home directory. Bash will read this file and disable bracketed paste mode. I tested it interactively with `bind 'set enable-bracketed-paste 0'` and it seemed to work.

Source: https://stackoverflow.com/questions/42212099/how-do-i-disable-the-weird-characters-from-bracketed-paste-mode-on-the-mac-os/72071483#72071483

## security considerations
None.